### PR TITLE
Ros node interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_CXX_STANDARD 20)
 # Dependencies
 
 find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+find_package(aaveq_ros_interfaces REQUIRED)
 
 ############################################################################
 
@@ -45,11 +50,19 @@ install(
 
 target_link_libraries(lib_ap_json socket_example)
 
-
 ############################################################################
 
-# Executables
+# Nodes (C++)
 
+# sim_interface
+add_executable(sim_interface nodes/sim_interface.cpp)
+ament_target_dependencies(sim_interface rclcpp std_msgs geometry_msgs aaveq_ros_interfaces)
+target_link_libraries(sim_interface lib_ap_json)
+
+
+install(TARGETS
+  sim_interface
+DESTINATION lib/${PROJECT_NAME})
 
 ############################################################################
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# ardupilot_sitl_sim_interface
-Interface between ArduPilot's SITL simulaiton and custom physics simulations using ROS 2
+# ArduPilot SITL and Simulaiton Interface
+
+Interface between ArduPilot's SITL and custom physics simulations using ROS 2.
+
+## Content 
+
+This package contains [library files](https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON) that interfaces with ArduPilot through UDP, which are files taken from the [ArduPilot Repository](https://github.com/ArduPilot/ardupilot/tree/master), and a node that handles the publishing and subscription of relevant topics.
+
+### Node: sim_interface
+
+#### Topics
+
+| Name      |Type   | I/O   |
+| ---       | ---   | ---   |
+| sim_state | [`aaveq_ros_interfaces::msg::SimState`](https://github.com/Aaveq-Robotics/aaveq_ros_interfaces/blob/main/msg/SimState.msg) | Subscriber |
+| control_output | [`aaveq_ros_interfaces::msg::ControlOutput`](https://github.com/Aaveq-Robotics/aaveq_ros_interfaces/blob/main/msg/ControlOutput.msg) | Publisher |
+
+## Usage
+
+1. Run node:
+    ```
+     ros2 run ardupilot_sitl_sim_interface sim_interface
+    ```
+
+2. Run custom physics engine.
+
+3. Run ArduPilots SITL in JSON mode:
+
+    ```
+    sim_vehicle.py -v Rover -f JSON --map
+    ```
+    Alternatively load with custom parameter file:
+
+    ```
+    sim_vehicle.py -v Rover -f JSON --map --add-param-file=<name>.parm
+    ```

--- a/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
+++ b/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
@@ -23,7 +23,7 @@ class libAP_JSON
 {
 public:
     bool InitSockets(const char *fdm_address, const uint16_t fdm_port_in);
-    bool ReceiveServoPacket(std::array<uint16_t, 16> servo_out);
+    bool ReceiveServoPacket(std::array<uint16_t, 16> &servo_out);
     void SendState(double timestamp,
                    double gyro_x, double gyro_y, double gyro_z,    // rad/sec
                    double accel_x, double accel_y, double accel_z, // m/s^2

--- a/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
+++ b/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
@@ -19,21 +19,23 @@
 
 #include "ardupilot_sitl_sim_interface/socket_example.hpp"
 
-class libAP_JSON {
+class libAP_JSON
+{
 public:
     bool InitSockets(const char *fdm_address, const uint16_t fdm_port_in);
     bool ReceiveServoPacket(std::array<uint16_t, 16> servo_out);
     void SendState(double timestamp,
-                   double gyro_x, double gyro_y, double gyro_z, // rad/sec
+                   double gyro_x, double gyro_y, double gyro_z,    // rad/sec
                    double accel_x, double accel_y, double accel_z, // m/s^2
-                   double pos_x, double pos_y, double pos_z, // m in inertial frame
-                   double phi, double theta, double psi, // attitude radians
-                   double V_x, double V_y, double V_z); // m/s in inertial frame
-    void setAirspeed(double airspeed_in); // m/s
-    void setWindvane(double direction, // radians clockwise to the front (0 is head to wind)
-                     double speed); // m/s
+                   double pos_x, double pos_y, double pos_z,       // m in inertial frame
+                   double phi, double theta, double psi,           // attitude radians
+                   double V_x, double V_y, double V_z);            // m/s in inertial frame
+    void setAirspeed(double airspeed_in);                          // m/s
+    void setWindvane(double direction,                             // radians clockwise to the front (0 is head to wind)
+                     double speed);                                // m/s
     void setRangefinder(double *rangefinder_in, uint8_t n);
     bool ap_online;
+
 private:
     // Socket manager
     SocketExample sock = SocketExample(true);

--- a/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
+++ b/include/ardupilot_sitl_sim_interface/lib_ap_json.hpp
@@ -22,7 +22,7 @@
 class libAP_JSON {
 public:
     bool InitSockets(const char *fdm_address, const uint16_t fdm_port_in);
-    bool ReceiveServoPacket(uint16_t servo_out[]);
+    bool ReceiveServoPacket(std::array<uint16_t, 16> servo_out);
     void SendState(double timestamp,
                    double gyro_x, double gyro_y, double gyro_z, // rad/sec
                    double accel_x, double accel_y, double accel_z, // m/s^2

--- a/include/ardupilot_sitl_sim_interface/socket_example.hpp
+++ b/include/ardupilot_sitl_sim_interface/socket_example.hpp
@@ -28,44 +28,47 @@
 #include <arpa/inet.h>
 #include <sys/select.h>
 
-class SocketExample {
+class SocketExample
+{
 public:
-    SocketExample(bool _datagram);
-    SocketExample(bool _datagram, int _fd);
-    ~SocketExample();
+  SocketExample(bool _datagram);
+  SocketExample(bool _datagram, int _fd);
+  ~SocketExample();
 
-    bool connect(const char *address, uint16_t port);
-    bool bind(const char *address, uint16_t port);
-    bool reuseaddress() const;
-    bool set_blocking(bool blocking) const;
-    bool set_cloexec() const;
-    void set_broadcast(void) const;
+  bool connect(const char *address, uint16_t port);
+  bool bind(const char *address, uint16_t port);
+  bool reuseaddress() const;
+  bool set_blocking(bool blocking) const;
+  bool set_cloexec() const;
+  void set_broadcast(void) const;
 
-    ssize_t send(const void *pkt, size_t size) const;
-    ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
-    ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
+  ssize_t send(const void *pkt, size_t size) const;
+  ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
+  ssize_t recv(void *pkt, size_t size, uint32_t timeout_ms);
 
-    // return the IP address and port of the last received packet
-    void last_recv_address(const char *&ip_addr, uint16_t &port) const;
+  // return the IP address and port of the last received packet
+  void last_recv_address(const char *&ip_addr, uint16_t &port) const;
 
-    // return true if there is pending data for input
-    bool pollin(uint32_t timeout_ms);
+  // return true if there is pending data for input
+  bool pollin(uint32_t timeout_ms);
 
-    // return true if there is room for output data
-    bool pollout(uint32_t timeout_ms);
+  // return true if there is room for output data
+  bool pollout(uint32_t timeout_ms);
 
-    // start listening for new tcp connections
-    bool listen(uint16_t backlog) const;
+  // start listening for new tcp connections
+  bool listen(uint16_t backlog) const;
 
-    // accept a new connection. Only valid for TCP connections after
-    // listen has been used. A new socket is returned
-    SocketExample *accept(uint32_t timeout_ms);
+  // accept a new connection. Only valid for TCP connections after
+  // listen has been used. A new socket is returned
+  SocketExample *accept(uint32_t timeout_ms);
 
 private:
-    bool datagram;
-    struct sockaddr_in in_addr {};
+  bool datagram;
+  struct sockaddr_in in_addr
+  {
+  };
 
-    int fd = -1;
+  int fd = -1;
 
-    void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
+  void make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr);
 };

--- a/nodes/sim_interface.cpp
+++ b/nodes/sim_interface.cpp
@@ -1,0 +1,80 @@
+#include <array>
+#include <chrono>
+#include <time.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <geometry_msgs/msg/point.hpp>
+
+#include "aaveq_ros_interfaces/msg/control_output.hpp"
+#include "aaveq_ros_interfaces/msg/sim_state.hpp"
+#include "ardupilot_sitl_sim_interface/lib_ap_json.hpp"
+
+class SimInterface : public rclcpp::Node
+{
+public:
+    SimInterface() : Node("sim_interface")
+    {
+        /***** Parameters *****/
+
+        /***** Subscription *****/
+        subscriber_sim_state_ = this->create_subscription<aaveq_ros_interfaces::msg::SimState>("sim_state", 1, std::bind(&SimInterface::callback_sim_state, this, std::placeholders::_1));
+
+        /***** Publishers *****/
+        publisher_control_output_ = this->create_publisher<aaveq_ros_interfaces::msg::ControlOutput>("control_output", 1);
+
+        /***** Init Variables *****/
+        // init the ArduPilot connection
+        if (ap_json.InitSockets("127.0.0.1", 9002))
+            RCLCPP_INFO_STREAM(get_logger(), "Started socket");
+    }
+
+private:
+    /***** Variables *****/
+    // Node parameters
+
+    // Node variables
+    rclcpp::Subscription<aaveq_ros_interfaces::msg::SimState>::SharedPtr subscriber_sim_state_;
+    rclcpp::Publisher<aaveq_ros_interfaces::msg::ControlOutput>::SharedPtr publisher_control_output_;
+
+    // Variables
+    libAP_JSON ap_json;
+    std::array<uint16_t, 16> servo_out;
+
+    /***** Callbacks *****/
+    void callback_sim_state(const aaveq_ros_interfaces::msg::SimState::SharedPtr msg)
+    {
+        if (!ap_json.ap_online)
+        {
+            RCLCPP_WARN_STREAM(get_logger(), "Recieved simulation data, but ArduPilot is not online");
+            return;
+        }
+
+        // Send state to ArduPilot
+        ap_json.SendState(msg->timestamp,
+                          msg->gyro.x, msg->gyro.y, msg->gyro.z,              // gyro
+                          msg->accel.x, msg->accel.y, msg->accel.z,           // accel
+                          msg->position.x, msg->position.y, msg->position.z,  // position
+                          msg->attitude.x, msg->attitude.y, msg->attitude.z,  // attitude
+                          msg->velocity.x, msg->velocity.y, msg->velocity.z); // velocity
+
+        // Recieve servo output from ArduPilot controller
+        if (ap_json.ReceiveServoPacket(servo_out))
+        {
+            aaveq_ros_interfaces::msg::ControlOutput msg_servo_out;
+
+            std::copy(servo_out.begin(), servo_out.end(),
+                      std::back_inserter(msg_servo_out.servo_pwm));
+
+            publisher_control_output_->publish(msg_servo_out);
+        }
+    }
+};
+
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<SimInterface>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/nodes/sim_interface.cpp
+++ b/nodes/sim_interface.cpp
@@ -47,12 +47,17 @@ private:
         // Recieve servo output from ArduPilot controller
         if (ap_json.ReceiveServoPacket(servo_out))
         {
-            aaveq_ros_interfaces::msg::ControlOutput msg_servo_out;
+            bool non_zero = std::any_of(servo_out.begin(), servo_out.end(), [](bool elem)
+                                        { return elem != 0; });
 
-            std::copy(servo_out.begin(), servo_out.end(),
-                      std::back_inserter(msg_servo_out.servo_pwm));
+            if (non_zero)
+            {
+                aaveq_ros_interfaces::msg::ControlOutput msg_servo_out;
+                std::copy(servo_out.begin(), servo_out.end(),
+                          std::back_inserter(msg_servo_out.servo_pwm));
 
-            publisher_control_output_->publish(msg_servo_out);
+                publisher_control_output_->publish(msg_servo_out);
+            }
         }
 
         if (!ap_json.ap_online) // Has to be called after libAP_JSON::ReceiveServoPacket()

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <depend>aaveq_ros_interfaces</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/lib_ap_json.cpp
+++ b/src/lib_ap_json.cpp
@@ -18,6 +18,8 @@
  * Adapted from Pierre Kancir's ArduPilot plugin for Gazebo
  */
 
+#include <array>
+
 #include "ardupilot_sitl_sim_interface/lib_ap_json.hpp"
 
 #define DEBUG_ENABLED 0
@@ -50,7 +52,8 @@ bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in
     return true;
 }
 
-bool libAP_JSON::ReceiveServoPacket(uint16_t servo_out[]) {
+bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
+{
     // Added detection for whether ArduPilot is online or not.
     // If ArduPilot is detected (receive of fdm packet from someone),
     // then socket receive wait time is increased from 1ms to 1 sec

--- a/src/lib_ap_json.cpp
+++ b/src/lib_ap_json.cpp
@@ -56,7 +56,7 @@ bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in
     return true;
 }
 
-bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
+bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> &servo_out)
 {
     // Added detection for whether ArduPilot is online or not.
     // If ArduPilot is detected (receive of fdm packet from someone),

--- a/src/lib_ap_json.cpp
+++ b/src/lib_ap_json.cpp
@@ -28,14 +28,16 @@
 #define MAX_SERVO_CHANNELS 16
 
 // The servo packet received from ArduPilot SITL. Defined in SIM_JSON.h.
-struct servo_packet {
+struct servo_packet
+{
     uint16_t magic; // 18458 expected magic value
     uint16_t frame_rate;
     uint32_t frame_count;
     uint16_t pwm[16];
 };
 
-bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in) {
+bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in)
+{
     // configure port
     sock.set_blocking(false);
     sock.reuseaddress();
@@ -43,11 +45,13 @@ bool libAP_JSON::InitSockets(const char *fdm_address, const uint16_t fdm_port_in
     // bind the socket
     if (!sock.bind(fdm_address, fdm_port_in))
     {
-        std::cout << "[libAP_JSON] " << "failed to bind with "
+        std::cout << "[libAP_JSON] "
+                  << "failed to bind with "
                   << fdm_address << ":" << fdm_port_in << std::endl;
         return false;
     }
-    std::cout << "[libAP_JSON] " << "flight dynamics model at "
+    std::cout << "[libAP_JSON] "
+              << "flight dynamics model at "
               << fdm_address << ":" << fdm_port_in << std::endl;
     return true;
 }
@@ -64,12 +68,15 @@ bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
     // missed receives before declaring the FCS offline.
 
     uint32_t waitMs;
-    if (ap_online) {
+    if (ap_online)
+    {
         // Increase timeout for recv once we detect a packet from ArduPilot FCS.
         // If this value is too high then it will block the main Gazebo update loop
         // and adversely affect the RTF.
         waitMs = 10;
-    } else {
+    }
+    else
+    {
         // Otherwise skip quickly and do not set control force.
         waitMs = 1;
     }
@@ -83,27 +90,35 @@ bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
 
     // drain the socket in the case we're backed up
     int counter = 0;
-    while (true) {
+    while (true)
+    {
         servo_packet last_pkt;
         auto recvSize_last = sock.recv(&last_pkt, sizeof(servo_packet), 0ul);
-        if (recvSize_last == -1) {
+        if (recvSize_last == -1)
+        {
             break;
         }
         counter++;
         pkt = last_pkt;
         recvSize = recvSize_last;
     }
-    if (counter > 0) {
-        std::cout << "[libAP_JSON] " << "Drained n packets: " << counter << std::endl;
+    if (counter > 0)
+    {
+        std::cout << "[libAP_JSON] "
+                  << "Drained n packets: " << counter << std::endl;
     }
 
     // didn't receive a packet, increment timeout count if online, then return
-    if (recvSize == -1) {
-        if (ap_online) {
-            if (++connectionTimeoutCount > connectionTimeoutMaxCount) {
+    if (recvSize == -1)
+    {
+        if (ap_online)
+        {
+            if (++connectionTimeoutCount > connectionTimeoutMaxCount)
+            {
                 connectionTimeoutCount = 0;
                 ap_online = false;
-                std::cout << "[libAP_JSON] " << "Broken ArduPilot connection (no packets received)" << std::endl;
+                std::cout << "[libAP_JSON] "
+                          << "Broken ArduPilot connection (no packets received)" << std::endl;
             }
         }
         return false;
@@ -116,7 +131,8 @@ bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
     std::cout << "frame_rate: " << pkt.frame_rate << "\n";
     std::cout << "frame_count: " << pkt.frame_count << "\n";
     std::cout << "pwm: [";
-    for (auto i = 0; i < MAX_SERVO_CHANNELS - 1; ++i) {
+    for (auto i = 0; i < MAX_SERVO_CHANNELS - 1; ++i)
+    {
         std::cout << pkt.pwm[i] << ", ";
     }
     std::cout << pkt.pwm[MAX_SERVO_CHANNELS - 1] << "]\n";
@@ -125,23 +141,27 @@ bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
 
     // check magic, return if invalid
     const uint16_t magic = 18458;
-    if (magic != pkt.magic) {
+    if (magic != pkt.magic)
+    {
         std::cout << "[libAP_JSON] Incorrect protocol magic " << pkt.magic << " should be " << magic << "\n";
         return false;
     }
 
     // check frame rate and frame order
     fcu_frame_rate = pkt.frame_rate;
-    if (pkt.frame_count < fcu_frame_count) {
+    if (pkt.frame_count < fcu_frame_count)
+    {
         // @TODO - implement re-initialisation
         std::cout << "[libAP_JSON] ArduPilot controller has reset\n";
     }
-    else if (pkt.frame_count == fcu_frame_count) {
+    else if (pkt.frame_count == fcu_frame_count)
+    {
         // received duplicate frame, skip
         std::cout << "[libAP_JSON] Duplicate input frame count" << fcu_frame_count << "\n";
         return false;
     }
-    else if (pkt.frame_count != fcu_frame_count + 1 && ap_online) {
+    else if (pkt.frame_count != fcu_frame_count + 1 && ap_online)
+    {
         // missed frames, warn only
         std::cout << "[libAP_JSON] Missed " << fcu_frame_count - pkt.frame_count << " input frames\n";
     }
@@ -149,26 +169,29 @@ bool libAP_JSON::ReceiveServoPacket(std::array<uint16_t, 16> servo_out)
 
     // always reset the connection timeout so we don't accumulate
     connectionTimeoutCount = 0;
-    if (!ap_online) {
+    if (!ap_online)
+    {
         ap_online = true;
 
-        std::cout << "[libAP_JSON] " << "Connected to ArduPilot controller @ "
+        std::cout << "[libAP_JSON] "
+                  << "Connected to ArduPilot controller @ "
                   << fcu_address << ":" << fcu_port_out << "\n";
     }
 
-    for (int i = 0; i < MAX_SERVO_CHANNELS - 1; i++) {
+    for (int i = 0; i < MAX_SERVO_CHANNELS - 1; i++)
+    {
         servo_out[i] = pkt.pwm[i];
     }
 
     return true;
 }
 
-void libAP_JSON::SendState(double timestamp, // seconds
-                           double gyro_x, double gyro_y, double gyro_z, // rad/sec
+void libAP_JSON::SendState(double timestamp,                               // seconds
+                           double gyro_x, double gyro_y, double gyro_z,    // rad/sec
                            double accel_x, double accel_y, double accel_z, // m/s^2
-                           double pos_x, double pos_y, double pos_z, // m in inertial frame
-                           double phi, double theta, double psi, // attitude radians
-                           double V_x, double V_y, double V_z) // m/s (standard fixed wing frame is negative)
+                           double pos_x, double pos_y, double pos_z,       // m in inertial frame
+                           double phi, double theta, double psi,           // attitude radians
+                           double V_x, double V_y, double V_z)             // m/s (standard fixed wing frame is negative)
 {
     // it is assumed that the imu orientation is NED, i.e.:
     //   x forward
@@ -182,31 +205,28 @@ void libAP_JSON::SendState(double timestamp, // seconds
 
     // build JSON string
     // all the required pieces first
-    std::string s =  "\n{\"timestamp\":" + std::to_string(timestamp)
-                    + ",\"imu\":{"
-                        + "\"gyro\":[" + std::to_string(gyro_x) + "," + std::to_string(gyro_y) + "," + std::to_string(gyro_z) + "]"
-                        + ",\"accel_body\":[" + std::to_string(accel_x) + "," + std::to_string(accel_y) + "," + std::to_string(accel_z) + "]"
-                        + "}"
-                    + ",\"position\":[" + std::to_string(pos_x) + "," + std::to_string(pos_y) + "," + std::to_string(pos_z) + "]"
-                    + ",\"attitude\":[" + std::to_string(phi) + "," + std::to_string(theta) + "," + std::to_string(psi) + "]"
-                    + ",\"velocity\":[" + std::to_string(V_x) + "," + std::to_string(V_y) + "," + std::to_string(V_z) + "]";
-    
+    std::string s = "\n{\"timestamp\":" + std::to_string(timestamp) + ",\"imu\":{" + "\"gyro\":[" + std::to_string(gyro_x) + "," + std::to_string(gyro_y) + "," + std::to_string(gyro_z) + "]" + ",\"accel_body\":[" + std::to_string(accel_x) + "," + std::to_string(accel_y) + "," + std::to_string(accel_z) + "]" + "}" + ",\"position\":[" + std::to_string(pos_x) + "," + std::to_string(pos_y) + "," + std::to_string(pos_z) + "]" + ",\"attitude\":[" + std::to_string(phi) + "," + std::to_string(theta) + "," + std::to_string(psi) + "]" + ",\"velocity\":[" + std::to_string(V_x) + "," + std::to_string(V_y) + "," + std::to_string(V_z) + "]";
+
     // handle the optional JSON data
-    if (set_airspeed_flag) {
+    if (set_airspeed_flag)
+    {
         s = s + ",\"airspeed\":" + std::to_string(airspeed);
     }
-    if (set_windvane_flag) {
+    if (set_windvane_flag)
+    {
         s = s + ",\"windvane\":{\"direction\":" + std::to_string(windvane_direction) + ",\"speed\":" + std::to_string(windvane_speed) + "}";
     }
-    if (rangefinder_count > 0) {
-        for (int i = 0; i < rangefinder_count; i++) {
+    if (rangefinder_count > 0)
+    {
+        for (int i = 0; i < rangefinder_count; i++)
+        {
             // rangefinder data is 1 indexed
             s = s + ",\"rng_" + std::to_string(i + 1) + "\":" + std::to_string(rangefinder[i]);
         }
     }
 
     s = s + "}\n"; // close the JSON
-    
+
     // send JSON string to ArduPilot
     auto bytes_sent = sock.sendto(
         s.c_str(), s.size(),
@@ -233,12 +253,16 @@ void libAP_JSON::setWindvane(double direction, double speed)
 
 void libAP_JSON::setRangefinder(double *rangefinder_in, uint8_t n)
 {
-    if (n <= 6) {
+    if (n <= 6)
+    {
         rangefinder_count = n;
-        for (int i = 0; i < n; i++) {
+        for (int i = 0; i < n; i++)
+        {
             rangefinder[i] = rangefinder_in[i];
         }
-    } else {
+    }
+    else
+    {
         std::cout << "[libAP_JSON] Too many rangerfinder values!" << std::endl;
     }
 }

--- a/src/socket_example.cpp
+++ b/src/socket_example.cpp
@@ -18,16 +18,16 @@
 /*
   constructor
  */
-SocketExample::SocketExample(bool _datagram) : 
-    SocketExample(_datagram, socket(AF_INET, _datagram?SOCK_DGRAM:SOCK_STREAM, 0)) 
-{}
+SocketExample::SocketExample(bool _datagram) : SocketExample(_datagram, socket(AF_INET, _datagram ? SOCK_DGRAM : SOCK_STREAM, 0))
+{
+}
 
-SocketExample::SocketExample(bool _datagram, int _fd) :
-    datagram(_datagram),
-    fd(_fd)
+SocketExample::SocketExample(bool _datagram, int _fd) : datagram(_datagram),
+                                                        fd(_fd)
 {
     fcntl(fd, F_SETFD, FD_CLOEXEC);
-    if (!datagram) {
+    if (!datagram)
+    {
         int one = 1;
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
     }
@@ -35,7 +35,8 @@ SocketExample::SocketExample(bool _datagram, int _fd) :
 
 SocketExample::~SocketExample()
 {
-    if (fd != -1) {
+    if (fd != -1)
+    {
         ::close(fd);
         fd = -1;
     }
@@ -61,7 +62,8 @@ bool SocketExample::connect(const char *address, uint16_t port)
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);
 
-    if (::connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+    if (::connect(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0)
+    {
         return false;
     }
     return true;
@@ -75,12 +77,12 @@ bool SocketExample::bind(const char *address, uint16_t port)
     struct sockaddr_in sockaddr;
     make_sockaddr(address, port, sockaddr);
 
-    if (::bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0) {
+    if (::bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != 0)
+    {
         return false;
     }
     return true;
 }
-
 
 /*
   set SO_REUSEADDR
@@ -97,9 +99,12 @@ bool SocketExample::reuseaddress(void) const
 bool SocketExample::set_blocking(bool blocking) const
 {
     int fcntl_ret;
-    if (blocking) {
+    if (blocking)
+    {
         fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_NONBLOCK);
-    } else {
+    }
+    else
+    {
         fcntl_ret = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
     }
     return fcntl_ret != -1;
@@ -136,7 +141,8 @@ ssize_t SocketExample::sendto(const void *buf, size_t size, const char *address,
  */
 ssize_t SocketExample::recv(void *buf, size_t size, uint32_t timeout_ms)
 {
-    if (!pollin(timeout_ms)) {
+    if (!pollin(timeout_ms))
+    {
         return -1;
     }
     socklen_t len = sizeof(in_addr);
@@ -155,7 +161,7 @@ void SocketExample::last_recv_address(const char *&ip_addr, uint16_t &port) cons
 void SocketExample::set_broadcast(void) const
 {
     int one = 1;
-    setsockopt(fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
+    setsockopt(fd, SOL_SOCKET, SO_BROADCAST, (char *)&one, sizeof(one));
 }
 
 /*
@@ -172,12 +178,12 @@ bool SocketExample::pollin(uint32_t timeout_ms)
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000UL;
 
-    if (select(fd+1, &fds, nullptr, nullptr, &tv) != 1) {
+    if (select(fd + 1, &fds, nullptr, nullptr, &tv) != 1)
+    {
         return false;
     }
     return true;
 }
-
 
 /*
   return true if there is room for output data
@@ -193,13 +199,14 @@ bool SocketExample::pollout(uint32_t timeout_ms)
     tv.tv_sec = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000UL;
 
-    if (select(fd+1, nullptr, &fds, nullptr, &tv) != 1) {
+    if (select(fd + 1, nullptr, &fds, nullptr, &tv) != 1)
+    {
         return false;
     }
     return true;
 }
 
-/* 
+/*
    start listening for new tcp connections
  */
 bool SocketExample::listen(uint16_t backlog) const
@@ -213,12 +220,14 @@ bool SocketExample::listen(uint16_t backlog) const
 */
 SocketExample *SocketExample::accept(uint32_t timeout_ms)
 {
-    if (!pollin(timeout_ms)) {
+    if (!pollin(timeout_ms))
+    {
         return nullptr;
     }
 
     int newfd = ::accept(fd, nullptr, nullptr);
-    if (newfd == -1) {
+    if (newfd == -1)
+    {
         return nullptr;
     }
     // turn off nagle for lower latency


### PR DESCRIPTION
**WHY**

Future simulations will use ROS 2 to interface with controllers, including ArduPilots SITL. 
ArduPolit does not use a ROS node currently to transfer data of control output or physics state inputs.

**WHAT**

An intermediate link, a ROS node, has been created.